### PR TITLE
GitHub Actionsワークフローの更新

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,22 +29,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Elm artifact
         uses: jorelali/setup-elm@v5
         with:
           elm-version: 0.19.1
-      - run: elm make src/Main.elm
+      - run: elm make src/Main.elm --optimize
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
           
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
## 変更内容

- GitHub Actionsのワークフローを最新バージョンに更新
  - `actions/checkout@v3` → `actions/checkout@v4`
  - `actions/configure-pages@v3` → `actions/configure-pages@v4`
  - `actions/upload-pages-artifact@v1` → `actions/upload-pages-artifact@v3`
  - `actions/deploy-pages@v2` → `actions/deploy-pages@v3`
- Elmビルドに最適化フラグを追加: `elm make src/Main.elm --optimize`

これらの変更により、GitHub Pagesへのデプロイが正常に行われるようになります。